### PR TITLE
[WIP] Hold and drag to switch to top

### DIFF
--- a/Demo/TableController.swift
+++ b/Demo/TableController.swift
@@ -1,8 +1,10 @@
 import UIKit
 import Lift
 
-class TableController: UIViewController, BottomControllable {
+class TableController: UIViewController {
     weak var bottomControllerDelegate: BottomControllerDelegate?
+    var onTopOfScrollView = false
+    var lastContentOffsetY = CGFloat(0.0)
 
     var cellIdentifier: String {
         return String(describing: UITableViewCell.self)
@@ -36,22 +38,38 @@ class TableController: UIViewController, BottomControllable {
     }
 }
 
-extension TableController: UITableViewDelegate, UITableViewDataSource {
+extension TableController: BottomControllable {
+    func enableScrollView() {
+        self.tableView.isUserInteractionEnabled = true
+    }
+}
 
+extension TableController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 40
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: self.cellIdentifier, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: self.cellIdentifier, for: indexPath) as! UITableViewCell
         cell.textLabel?.text = "Hi there"
 
         return cell
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y < -(UIScreen.main.bounds.height / 4) {
-            self.bottomControllerDelegate?.requestToSwitchToTop(from: self)
+        let scrollingUp = self.lastContentOffsetY > scrollView.contentOffset.y
+
+        let scrollingUpFromTop = self.onTopOfScrollView && scrollingUp
+
+        if scrollingUpFromTop {
+            scrollView.isUserInteractionEnabled = false
+            scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
         }
+
+        self.lastContentOffsetY = scrollView.contentOffset.y
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        self.onTopOfScrollView = scrollView.contentOffset.y <= 0
     }
 }

--- a/Demo/TableController.swift
+++ b/Demo/TableController.swift
@@ -64,6 +64,7 @@ extension TableController: UITableViewDelegate, UITableViewDataSource {
         if scrollingUpFromTop {
             scrollView.isUserInteractionEnabled = false
             scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
+            self.bottomControllerDelegate?.requestToScrollOnTop(toYOffset: scrollView.contentOffset.y, from: self)
         }
 
         self.lastContentOffsetY = scrollView.contentOffset.y

--- a/Demo/TableController.swift
+++ b/Demo/TableController.swift
@@ -63,7 +63,6 @@ extension TableController: UITableViewDelegate, UITableViewDataSource {
 
         if scrollingUpFromTop {
             scrollView.isUserInteractionEnabled = false
-            scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
             self.bottomControllerDelegate?.requestToScrollOnTop(toYOffset: scrollView.contentOffset.y, from: self)
         }
 

--- a/Sources/BottomControllable.swift
+++ b/Sources/BottomControllable.swift
@@ -2,9 +2,12 @@ import UIKit
 
 public protocol BottomControllerDelegate: class {
     func requestToSwitchToTop(from bottomController: BottomControllable)
+    func requestToScrollOnTop(toYOffset yOffset: CGFloat, from bottomController: BottomControllable)
 }
 
 public protocol BottomControllable: class {
+    func enableScrollView()
+
     weak var bottomControllerDelegate: BottomControllerDelegate? { get set }
     var controllerTitle: String? { get set }
     var defaultView: UIView { get set }

--- a/Sources/BottomScrollViewController.swift
+++ b/Sources/BottomScrollViewController.swift
@@ -120,6 +120,13 @@ class BottomScrollViewController: UIViewController {
             controller.didMove(toParentViewController: parentController)
         }
     }
+
+    func enableScrollViews() {
+        print("enable all the ScrollViews!")
+        for bottomViewController in self.bottomViewControllers ?? [] {
+           bottomViewController.enableScrollView()
+        }
+    }
 }
 
 extension BottomScrollViewController: UIScrollViewDelegate {
@@ -151,17 +158,12 @@ extension BottomScrollViewController: HorizontallySwitchableDelegate {
         UIView.animate(withDuration: 0.2, animations: {
             self.scrollView.bounds = scrollBounds
         }, completion: { b in
+            if position != self.horizontalPosition {
+                self.horizontalPosition = position
 
-            // WARNING: look into this, can't i just use the horizontalPosition formt he delegate here?
-            let pageWidth = UIScreen.main.bounds.width
-            let horizontalPosition = Int(floor((self.scrollView.contentOffset.x - pageWidth / 2) / pageWidth) + 1)
-
-            if horizontalPosition != self.horizontalPosition {
-                self.horizontalPosition = horizontalPosition
-
-                self.loadScrollViewWithPage(horizontalPosition - 1)
-                self.loadScrollViewWithPage(horizontalPosition)
-                self.loadScrollViewWithPage(horizontalPosition + 1)
+                self.loadScrollViewWithPage(position - 1)
+                self.loadScrollViewWithPage(position)
+                self.loadScrollViewWithPage(position + 1)
             }
         })
     }
@@ -171,5 +173,9 @@ extension BottomScrollViewController: BottomControllerDelegate {
 
     func requestToSwitchToTop(from bottomContentViewController: BottomControllable) {
         self.verticallySwitchableDelegate?.didSwitchToPosition(.top, on: self)
+    }
+
+    func requestToScrollOnTop(toYOffset yOffset: CGFloat, from bottomController: BottomControllable) {
+        self.verticallySwitchableDelegate?.didScrollToYOffset(yOffset, on: self)
     }
 }

--- a/Sources/LiftNavigationController.swift
+++ b/Sources/LiftNavigationController.swift
@@ -131,6 +131,12 @@ extension LiftNavigationController: UIScrollViewDelegate {
         self.shouldEvaluatePageChange = false
     }
 
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        print("scrollViewDidEndDragging")
+        self.bottomScrollViewController.enableScrollViews()
+    }
+
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if shouldEvaluatePageChange {
             let pageHeight = self.view.bounds.height
@@ -166,5 +172,9 @@ extension LiftNavigationController: VerticallySwitchable, VerticallySwitchableDe
     func didSwitchToPosition(_ position: VerticalPosition, on viewController: UIViewController) {
         self.setVerticalPosition(position)
         self.verticallySwitchableDelegate?.didSwipeToPosition(position, on: self)
+    }
+
+    func didScrollToYOffset(_ yOffset: CGFloat, on viewController: UIViewController) {
+        self.scrollView.setContentOffset(CGPoint(x: 0, y: self.scrollView.contentOffset.y + yOffset), animated: false)
     }
 }

--- a/Sources/LiftNavigationController.swift
+++ b/Sources/LiftNavigationController.swift
@@ -175,6 +175,6 @@ extension LiftNavigationController: VerticallySwitchable, VerticallySwitchableDe
     }
 
     func didScrollToYOffset(_ yOffset: CGFloat, on viewController: UIViewController) {
-        self.scrollView.setContentOffset(CGPoint(x: 0, y: self.scrollView.contentOffset.y + yOffset), animated: false)
+        self.scrollView.setContentOffset(CGPoint(x: 0, y: 603 + yOffset), animated: false)
     }
 }

--- a/Sources/Protocols/VerticallySwitchable.swift
+++ b/Sources/Protocols/VerticallySwitchable.swift
@@ -8,12 +8,14 @@ enum VerticalPosition: Int {
 protocol VerticallySwitchableDelegate: class {
     func didSwipeToPosition(_ position: VerticalPosition, on viewController: UIViewController)
     func didSwitchToPosition(_ position: VerticalPosition, on viewController: UIViewController)
+    func didScrollToYOffset(_ yOffset: CGFloat, on viewController: UIViewController)
 }
 
 extension VerticallySwitchableDelegate where Self: VerticallySwitchable {
     // make the methods optional
     func didSwipeToPosition(_ position: VerticalPosition, on viewController: UIViewController) {}
     func didSwitchToPosition(_ position: VerticalPosition, on viewController: UIViewController) {}
+    func didScrollToYOffset(_ yOffset: CGFloat, on viewController: UIViewController) {}
 }
 
 protocol VerticallySwitchable: class {


### PR DESCRIPTION
Trying to get the same 'hod and drag' behaviour when going from the bottom to the top, as has now from top to bottom.

It's not easy though since there is a scrollView or a tableView on the bottom view controllers that 'catches' of the drag movements that would otherwise be caught by the topScrollView containing these views. 

I want to do something like this:
```
let scrollingUpFromTop = self.onTopOfScrollView && scrollingUp
if scrollingUpFromTop {
    //send the movements to the top scrollView
} else {
    //just scroll the scroll or tableview on itself
```
 
I'm actually pretty close now! The problem is that since i need to to know the direction of the scroll, i can only detect this when the scroll on its own tableview has already started, so the changes I make then to let the touches be passed on to the top scrollView will only be effective when I'm done with my current scroll and start my next:

![swipe up](https://cloud.githubusercontent.com/assets/1125417/23999085/8a4d3256-0a57-11e7-86b8-2c78e33c03d2.gif)
here you see: 
on swipe 1. I recognize that the scrollView is on top and tat im trying to scroll upwards! So I disable user interaction on the tableView, and force my current scroll to stop ✌️
on swipe 2. Now the tableView doesnt recognize any interaction so my swipe goes to the top scrollview!  

But what i really need is some way to stop the active scroll on the tableView and seamlessly  have it been picked up by the top scrollView. Or maybe have the touches be recognized by a some other thing that can decide wether to send the touches to the topScrollView or the TableView

What do you think? Impossible or impossible?